### PR TITLE
Engage CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+
+jobs:
+  build:
+    working_directory: /go/src/github.com/gudtech/go-monetdb
+    docker:
+      - image: circleci/golang:1.10.3
+    steps:
+      - checkout
+      - run: go test -v -race ./...


### PR DESCRIPTION
Turn on CircleCI for this repository.

The build is very simple and the tests run without installing any dependencies.